### PR TITLE
Add Full Screen link to customizer's CSS editor.

### DIFF
--- a/customizer-link.css
+++ b/customizer-link.css
@@ -1,7 +1,21 @@
+.CodeMirror-wrap {
+	border-top: 0 none;
+}
+
+#fullscreenlinks {
+	background: #eee;
+}
+
 .css-help #fullscreen-link {
 	border-bottom: 0;
+	color: #aaa;
 	float: right;
 	padding-right: 5px;
+}
+
+.css-help a#fullscreen-link:hover {
+	background-color: #eee;
+	color: #0073aa;
 }
 
 .css-help a#fullscreen-link:before {

--- a/customizer-link.css
+++ b/customizer-link.css
@@ -1,0 +1,9 @@
+.css-help #fullscreen-link {
+	border-bottom: 0;
+	float: right;
+	padding-right: 5px;
+}
+
+.css-help a#fullscreen-link:before {
+	content: "\f211";
+}

--- a/customizer-link.js
+++ b/customizer-link.js
@@ -1,0 +1,15 @@
+jQuery(document).ready(function() {
+	jQuery( '<div />', {
+		id: 'fullscreenlinks',
+		'class': 'css-help'
+	}).prependTo( '.CodeMirror-wrap' );
+	jQuery( '<a />', {
+		id: 'fullscreen-link',
+		target: '_blank',
+		href: legacy_jetpack_css_settings.fullscreenURL
+	}).prependTo( '#fullscreenlinks' );
+	jQuery( '<span />', {
+		'class': 'screen-reader-text',
+		text: legacy_jetpack_css_settings.title
+	}).prependTo( '#fullscreen-link' );
+});

--- a/legacy-jetpack-custom-css-editor.php
+++ b/legacy-jetpack-custom-css-editor.php
@@ -5,7 +5,7 @@
  * Plugin URI: http://github.com/georgestephanis/legacy-jetpack-custom-css-editor
  * Description: This plugin re-adds the full page admin Custom CSS editor to Jetpack.
  * Author: George Stephanis
- * Version: 0.9
+ * Version: 0.9.1
  * Author URI: https://stephanis.info
  */
 
@@ -15,6 +15,8 @@
  *
  * Hopefully it will work that way in the future.
  */
+
+define( 'LEGACY_JP_CSS__VERSION', '0.9.1' );
 
 class Legacy_Jetpack_Custom_CSS_Editor {
 	/**
@@ -28,6 +30,7 @@ class Legacy_Jetpack_Custom_CSS_Editor {
 		add_action( 'admin_init', array( __CLASS__, 'admin_init' ) );
 		add_action( 'admin_post_legacy_jetpack_update_custom_css', array( __CLASS__, 'legacy_jetpack_update_custom_css' ) );
 		add_action( 'wp_ajax_legacy_jetpack_preview_custom_css', array( __CLASS__, 'legacy_jetpack_preview_custom_css' ) );
+		add_action( 'customize_controls_enqueue_scripts', array( __CLASS__, 'legacy_jetpack_enqueue_customizer_link' ) );
 	}
 
 	/**
@@ -41,8 +44,12 @@ class Legacy_Jetpack_Custom_CSS_Editor {
 		if ( ! class_exists( 'Jetpack_Custom_CSS_Enhancements' ) ) {
 			return;
 		}
-		wp_register_script( 'legacy-jetpack-custom-css-editor', plugins_url( 'use-codemirror.js', __FILE__ ), array( 'underscore', 'jetpack-codemirror' ), '0.1-dev', true );
+		wp_register_script( 'legacy-jetpack-custom-css-editor', plugins_url( 'use-codemirror.js', __FILE__ ), array( 'underscore', 'jetpack-codemirror' ), LEGACY_JP_CSS__VERSION, true );
 		wp_register_script( 'legacy-no-jetpack-custom-css-editor', plugins_url( 'no-jetpack', __FILE__ ) );
+
+		// Register script to add a full screen button to the customizer.
+		wp_register_script( 'legacy-jetpack-custom-css-customizer-link', plugins_url( 'customizer-link.js', __FILE__ ) );
+		wp_register_style( 'legacy-jetpack-custom-css-customizer-link', plugins_url( 'customizer-link.css', __FILE__ ), array( 'jetpack-customizer-css' ), LEGACY_JP_CSS__VERSION );
 	}
 
 	/**
@@ -333,6 +340,20 @@ class Legacy_Jetpack_Custom_CSS_Editor {
 			}
 		</style>
 		<?php
+	}
+
+	/**
+	 * Enqueue a JS file in the customizer, to output a link to the legacy editor.
+	 *
+	 * @since 0.9.1
+	 */
+	public static function legacy_jetpack_enqueue_customizer_link() {
+		wp_enqueue_style( 'legacy-jetpack-custom-css-customizer-link' );
+		wp_enqueue_script( 'legacy-jetpack-custom-css-customizer-link' );
+		wp_localize_script( 'legacy-jetpack-custom-css-customizer-link', 'legacy_jetpack_css_settings', array(
+			'fullscreenURL' => admin_url( 'themes.php?page=legacy-editcss' ),
+			'title' => _x( 'Full Screen', 'Toolbar button to access the CSS editor in a full-scren window.', 'jetpack' ),
+		));
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgestephanis
 Tags: custom css, jetpack
 Requires at least: 4.7
 Tested up to: 4.8-dev
-Stable tag: 0.9
+Stable tag: 0.9.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -20,6 +20,9 @@ but shortly it will work without Jetpack as well, providing a
 more basic text editor without syntax highlighting.
 
 == Changelog ==
+
+= 0.9.1 =
+* Add Full screen link to the CSS editor in the customiser.
 
 = 0.9 =
 * Preview works, powered by the Core Customizer's data store.


### PR DESCRIPTION
I thought it would be nice to use @folletto's mockup and add a full-screen button to the corner of the new editor, linking to the Legacy one.

![screen shot 2016-12-16 at 13 10 12](https://cloud.githubusercontent.com/assets/426388/21262329/1147b334-c391-11e6-884a-d93badf3fd72.png)

Here is the end result I got to:

![screen shot 2016-12-16 at 14 48 17](https://cloud.githubusercontent.com/assets/426388/21264987/7a13a9e6-c39f-11e6-9dda-0f40e4b578a0.png)

### In this PR

- Enqueue a small JS and a small CSS file to add the button to the customizer.
- Update version numbers.
- Update readme.
- Create plugin version constant for easier versioning of enqueued assets.

### To be improved

I assume my .js file is just ugly. It works, but there is most likely a cleaner way to do things. I should also probably add that CSS inline on the page instead of enqueuing a new file.

